### PR TITLE
Revert "Use `ember-concurrency-test-waiter` to prevent race conditions in tests"

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,11 +1,7 @@
 import Application from '@ember/application';
-import loadInitializers from 'ember-load-initializers';
-import defineModifier from 'ember-concurrency-test-waiter/define-modifier';
-
-import config from './config/environment';
 import Resolver from './resolver';
-
-defineModifier();
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/app/components/aircraft-status.js
+++ b/app/components/aircraft-status.js
@@ -72,7 +72,7 @@ export default Component.extend({
 
     let json = yield response.json();
     return json.data.attributes;
-  }).drop().withTestWaiter(),
+  }).drop(),
 
   actions: {
     refresh() {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
     "ember-concurrency": "^0.8.19",
-    "ember-concurrency-test-waiter": "^0.3.1",
     "ember-export-application-global": "^2.0.0",
     "ember-fetch": "^5.0.0",
     "ember-load-initializers": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,12 +2250,6 @@ ember-cli@~3.0.2:
     watch-detector "^0.1.0"
     yam "0.0.22"
 
-ember-concurrency-test-waiter@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ember-concurrency-test-waiter/-/ember-concurrency-test-waiter-0.3.1.tgz#9bdf83c532d17d913bbc29ee934266cd504f015a"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-concurrency@^0.8.19:
   version "0.8.19"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.19.tgz#71b9c175ba077865310029cb4bdb880e17d5155e"


### PR DESCRIPTION
This reverts commit 1c713a481586ccae0c3209dddd0c0e1b05cf2b1a.

ab198b4 removed the need for this.