### PR TITLE
CI: Use Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
----
 language: node_js
 node_js:
-  - "11"
+  - "12"
 
 addons:
   chrome: stable


### PR DESCRIPTION
Node 11 is no longer supported and is not an LTS release either.